### PR TITLE
Refactor compare_strings function

### DIFF
--- a/src/lsm/bpf_map_structs.h
+++ b/src/lsm/bpf_map_structs.h
@@ -42,12 +42,19 @@ static __always_inline __u64 get_cgroup_id() {
 }
 
 // Custom strncmp function for BPF
-static __always_inline int compare_strings(const char *a, const char *b, __u32 len) {
+static __always_inline int compare_strings(const char *a, const char *b, __u32 len, __u32 flags) {
+    bool is_recursive = flags & POLICY_RECURSIVE;
+
     for (__u32 i = 0; i < len; i++) {
-        if (a[i] == '\0') return 0;  // Equal
-        if (a[i] != b[i])return 1;  // Not equal
+        if (a[i] != b[i]) {
+            if (is_recursive && a[i] == '\0' && b[i] == '/') {
+                return 1;  
+            }
+            return 0; 
+        }
+        if (a[i] == '\0' && b[i] == '\0') return 1;
     }
-    return 0;  // Equal if both strings are of length `len` and match
+    return 0; 
 }
 
 static __always_inline int get_process_path(char *path_buf, int buf_size) {
@@ -144,7 +151,8 @@ static __always_inline __u32 match_policy(enum policy_type type, void *data) {
             for (int i = 0; i < MAX_POLICIES_PER_CONTAINER; i++) {
                 if (i >= value->num_file_policies)
                     break;
-                if (!compare_strings(value->file_policies[i].path, path, MAX_PATH_LENGTH))
+                __u32 flags = value->file_policies[i].flags;  // 정책 플래그 가져오기
+                if (compare_strings(value->file_policies[i].path, path, MAX_PATH_LENGTH,flags))
                     return value->file_policies[i].flags;
             }
             break;
@@ -170,7 +178,7 @@ static __always_inline __u32 match_policy(enum policy_type type, void *data) {
             for (int i = 0; i < MAX_POLICIES_PER_CONTAINER; i++) {
                 if (i >= value->num_process_policies)
                     break;
-                if (!compare_strings(value->process_policies[i].comm, comm, 16))
+                if (compare_strings(value->process_policies[i].comm, comm, 16,0))
                     return value->process_policies[i].flags;
             }
             break;

--- a/src/lsm/bpf_map_structs.h
+++ b/src/lsm/bpf_map_structs.h
@@ -48,13 +48,13 @@ static __always_inline int compare_strings(const char *a, const char *b, __u32 l
     for (__u32 i = 0; i < len; i++) {
         if (a[i] != b[i]) {
             if (is_recursive && a[i] == '\0' && b[i] == '/') {
-                return 1;  
+                return 0;  
             }
-            return 0; 
+            return 1; 
         }
-        if (a[i] == '\0' && b[i] == '\0') return 1;
+        if (a[i] == '\0' && b[i] == '\0') return 0;
     }
-    return 0; 
+    return 1; 
 }
 
 static __always_inline int get_process_path(char *path_buf, int buf_size) {
@@ -152,7 +152,7 @@ static __always_inline __u32 match_policy(enum policy_type type, void *data) {
                 if (i >= value->num_file_policies)
                     break;
                 __u32 flags = value->file_policies[i].flags;  // 정책 플래그 가져오기
-                if (compare_strings(value->file_policies[i].path, path, MAX_PATH_LENGTH,flags))
+                if (compare_strings(value->file_policies[i].path, path, MAX_PATH_LENGTH,flags) == 0)
                     return value->file_policies[i].flags;
             }
             break;
@@ -178,7 +178,7 @@ static __always_inline __u32 match_policy(enum policy_type type, void *data) {
             for (int i = 0; i < MAX_POLICIES_PER_CONTAINER; i++) {
                 if (i >= value->num_process_policies)
                     break;
-                if (compare_strings(value->process_policies[i].comm, comm, 16,0))
+                if (compare_strings(value->process_policies[i].comm, comm, 16,0) == 0)
                     return value->process_policies[i].flags;
             }
             break;


### PR DESCRIPTION


### Description
Updated compare_strings to handle **recursive path matching via flags** and to **return 1** only when paths are considered identical, aligning with the function’s intended behavior.

### Type of Change
<!---
Please delete options that are not relevant.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (code improvement that does not add functionality)
- [ ] Documentation update (README, changelog, or other documentation)
- [ ] Other (please explain):

### Checklist
<!---
Please check all relevant options.
-->

- [x ] I have read the [CONTRIBUTING.md](./.github/docs/CONTRIBUTING.md) document
- [x] My code follows the code style of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors

<!---
### Additional Notes

Please provide any additional context or information about the PR here.
-->

